### PR TITLE
Support multidimensional arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ julia> ]add UnicodeGraphics
 ```
 
 ## Examples
+By default, `uprint` prints all values greater than zero in an array:
 ```julia
 julia> pac = [
    0 0 0 0 0 0 0 1 1 1 1 1 1 0 0 0 0 0 0 0
@@ -56,7 +57,7 @@ julia> uprint(pac, :block)
      ▀▀██████▀▀     
 ```
 
-It is also possible to pass a filtering function, filling values for which the function returns `true`:
+It is also possible to pass a filtering function, filling values for which the function returns `true`, e.g. even numbers in the following array:
 ```julia
 julia> ghost = [
    1 7 7 7 7 8 6 4 6 3 9 9 9 7
@@ -80,9 +81,49 @@ julia> uprint(iseven, ghost)
 ⣿⢿⣿⠿⣿⡿⣿
 ⠁⠀⠉⠀⠉⠀⠈
 ```
-`uprint` can be used to write into any `IO` stream, defaulting to `stdout`.
 
-`ustring` can be used to return a string instead of printing to IO:
+Higher order arrays and non-number types are also supported, 
+as long as the filtering function returns boolean values:
+```julia-repl
+julia> A = rand("abc123", 4, 4, 1, 2)
+4×4×1×2 Array{Char, 4}:
+[:, :, 1, 1] =
+ 'a'  'b'  'c'  'a'
+ 'b'  '2'  'b'  '1'
+ 'a'  'b'  '1'  'a'
+ '1'  'b'  'a'  'b'
+
+[:, :, 1, 2] =
+ 'a'  '2'  '2'  '1'
+ 'a'  '2'  'a'  'c'
+ '3'  '2'  'c'  'b'
+ 'c'  'c'  'c'  '1'
+
+julia> uprint(isletter, A, :block)
+[:, :, 1, 1] =
+█▀█▀
+▀█▄█
+
+[:, :, 1, 2] =
+█ ▄▄
+▄▄█▀
+```
+
+`uprint` can be used to write into any `IO` stream, defaulting to `stdout`.
+```julia-repl
+julia> io = IOBuffer();
+
+julia> uprint(io, pac)
+
+julia> String(take!(io)) |> print
+⠀⣠⣴⣾⣿⣿⣷⣦⣄⠀
+⣰⣿⣿⣿⣧⣼⣿⡿⠟⠃
+⣿⣿⣿⣿⣿⣏⡁⠀⠀⠠
+⠹⣿⣿⣿⣿⣿⣿⣷⣦⡄
+⠀⠙⠻⢿⣿⣿⡿⠟⠋⠀
+```
+
+To directly return a string instead of printing to IO, `ustring` can be used:
 ```julia-repl
 julia> ustring(iseven, ghost)
 "⢀⠴⣾⣿⠷⣦⡀\n⣴⠆⣸⣷⠆⣸⣧\n⣿⢿⣿⠿⣿⡿⣿\n⠁⠀⠉⠀⠉⠀⠈\n"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ julia> ]add UnicodeGraphics
 ```
 
 ## Examples
-By default, `uprint` prints all values greater than zero in an array:
+By default, `uprint` prints all values in an array that are true or greater than zero:
 ```julia
 julia> pac = [
    0 0 0 0 0 0 0 1 1 1 1 1 1 0 0 0 0 0 0 0
@@ -57,7 +57,7 @@ julia> uprint(pac, :block)
      ▀▀██████▀▀     
 ```
 
-It is also possible to pass a filtering function, filling values for which the function returns `true`, e.g. even numbers in the following array:
+It is also possible to pass a filtering function, filling values for which the function returns `true`, e.g. all even numbers in the following array:
 ```julia
 julia> ghost = [
    1 7 7 7 7 8 6 4 6 3 9 9 9 7
@@ -82,31 +82,46 @@ julia> uprint(iseven, ghost)
 ⠁⠀⠉⠀⠉⠀⠈
 ```
 
-Higher order arrays and non-number types are also supported, 
+Non-number type inputs are also supported, 
 as long as the filtering function returns boolean values:
-```julia-repl
-julia> A = rand("abc123", 4, 4, 1, 2)
-4×4×1×2 Array{Char, 4}:
-[:, :, 1, 1] =
- 'a'  'b'  'c'  'a'
- 'b'  '2'  'b'  '1'
- 'a'  'b'  '1'  'a'
- '1'  'b'  'a'  'b'
 
-[:, :, 1, 2] =
- 'a'  '2'  '2'  '1'
- 'a'  '2'  'a'  'c'
- '3'  '2'  'c'  'b'
- 'c'  'c'  'c'  '1'
+```julia-repl
+julia> A = rand("abc123", 4, 4)
+4×4 Matrix{Char}:
+ '3'  'c'  '3'  '1'
+ 'a'  'c'  '1'  'c'
+ '1'  '1'  '2'  'a'
+ 'b'  'a'  '2'  'a'
 
 julia> uprint(isletter, A, :block)
+▄█ ▄
+▄▄ █
+```
+
+Multidimensional arrays are also supported:
+```julia-repl
+julia> A = rand(Bool, 4, 4, 1, 2)
+4×4×1×2 Array{Bool, 4}:
 [:, :, 1, 1] =
-█▀█▀
-▀█▄█
+ 0  1  0  0
+ 1  0  1  0
+ 0  1  1  1
+ 0  0  1  1
 
 [:, :, 1, 2] =
-█ ▄▄
-▄▄█▀
+ 1  1  0  0
+ 1  1  0  0
+ 0  0  1  0
+ 0  0  1  0
+
+julia> uprint(A, :block)
+[:, :, 1, 1] =
+▄▀▄ 
+ ▀██
+
+[:, :, 1, 2] =
+██  
+  █ 
 ```
 
 `uprint` can be used to write into any `IO` stream, defaulting to `stdout`.
@@ -125,9 +140,6 @@ julia> String(take!(io)) |> print
 
 To directly return a string instead of printing to IO, `ustring` can be used:
 ```julia-repl
-julia> ustring(iseven, ghost)
-"⢀⠴⣾⣿⠷⣦⡀\n⣴⠆⣸⣷⠆⣸⣧\n⣿⢿⣿⠿⣿⡿⣿\n⠁⠀⠉⠀⠉⠀⠈\n"
-
-julia> ustring(iseven, ghost, :block)
-"   ▄▄████▄▄   \n ▄▀▀████▀▀██▄ \n ▄▄  ██▄▄  ██ \n██▀ ▄███▀ ▄███\n██████████████\n██▀███▀▀███▀██\n▀   ▀▀  ▀▀   ▀\n"
+julia> ustring(pac)
+"⠀⣠⣴⣾⣿⣿⣷⣦⣄⠀\n⣰⣿⣿⣿⣧⣼⣿⡿⠟⠃\n⣿⣿⣿⣿⣿⣏⡁⠀⠀⠠\n⠹⣿⣿⣿⣿⣿⣿⣷⣦⡄\n⠀⠙⠻⢿⣿⣿⡿⠟⠋⠀\n"
 ```

--- a/src/UnicodeGraphics.jl
+++ b/src/UnicodeGraphics.jl
@@ -5,6 +5,7 @@ module UnicodeGraphics
 
 const DEFAULT_METHOD = :braille
 include("api.jl")
+include("ndarray.jl")
 include("core.jl")
 include("deprecate.jl")
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -30,8 +30,8 @@ julia> uprint(A, :block)
 ▄▄▀▄▄█ ▀
 ```
 """
-uprint(A::AbstractMatrix, method::Symbol=DEFAULT_METHOD) = uprint(stdout, A, method)
-function uprint(io::IO, A::AbstractMatrix, method::Symbol=DEFAULT_METHOD)
+uprint(A::AbstractArray, method::Symbol=DEFAULT_METHOD) = uprint(stdout, A, method)
+function uprint(io::IO, A::AbstractArray, method::Symbol=DEFAULT_METHOD)
     return uprint(io, >(zero(eltype(A))), A, method)
 end
 
@@ -67,18 +67,11 @@ julia> uprint(>(3), A, :block)
  ██ ██▀█
 ```
 """
-function uprint(f::Function, A::AbstractMatrix, method::Symbol=DEFAULT_METHOD)
+function uprint(f::Function, A::AbstractArray, method::Symbol=DEFAULT_METHOD)
     return uprint(stdout, f, A, method)
 end
-function uprint(io::IO, f::Function, A::AbstractMatrix, method::Symbol=DEFAULT_METHOD)
-    if method == :braille
-        to_braille(io, f, A)
-    elseif method == :block
-        to_block(io, f, A)
-    else
-        throw(ArgumentError("Valid methods are :braille and :block, got :$method."))
-    end
-    return nothing
+function uprint(io::IO, f::Function, A::AbstractArray, method::Symbol=DEFAULT_METHOD)
+    return _uprint_nd(io::IO, f::Function, A::AbstractArray, method::Symbol)
 end
 
 """
@@ -110,7 +103,7 @@ julia> ustring(A, :block)
 "█▀▀█▄█  \n█ ▄ █▄█▄\n ▄▄ ▄ ▀▄\n▄▄█▄ ▀██\n"
 ```
 """
-function ustring(A::AbstractMatrix, method::Symbol=DEFAULT_METHOD)
+function ustring(A::AbstractArray, method::Symbol=DEFAULT_METHOD)
     return ustring(>(zero(eltype(A))), A, method)
 end
 
@@ -143,7 +136,7 @@ julia> ustring(>(3), A, :block)
 "██▀▀██ ▀\n▄██▄██ █\n▄██▄  ██\n█▀█▄▄▀██\n"
 ```
 """
-function ustring(f::Function, A::AbstractMatrix, method::Symbol=DEFAULT_METHOD)
+function ustring(f::Function, A::AbstractArray, method::Symbol=DEFAULT_METHOD)
     io = IOBuffer()
     uprint(io, f, A, method)
     return String(take!(io))

--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -1,0 +1,40 @@
+# For matrices, directly call core.jl method matching method Symbol.
+function _uprint_nd(io::IO, f::Function, A::AbstractMatrix, method::Symbol)
+    if method == :braille
+        to_braille(io, f, A)
+    elseif method == :block
+        to_block(io, f, A)
+    else
+        throw(ArgumentError("Valid methods are :braille and :block, got :$method."))
+    end
+    return nothing
+end
+# View vectors as 1xn adjoints
+function _uprint_nd(io::IO, f::Function, v::AbstractVector, method::Symbol)
+    _uprint_nd(io, f, adjoint(v), method)
+    return nothing
+end
+
+# For multi-dimensional arrays, iterate over tail-indices
+function _uprint_nd(io::IO, f::Function, A::AbstractArray, method::Symbol)
+    axs= axes(A)
+    tailinds = Base.tail(Base.tail(axs))
+    Is = CartesianIndices(tailinds)
+    for I in Is
+        idxs = I.I
+        _show_nd_label(io, idxs)
+        slice = view(A, axs[1], axs[2], idxs...) # matrix-shaped slice
+        _uprint_nd(io, f, slice, method)
+        print(io, idxs == map(last,tailinds) ? "" : "\n")
+    end
+    return nothing
+end
+# adapted from Base._show_nd_label
+function _show_nd_label(io::IO, idxs)
+    print(io, "[:, :, ")
+    for i = 1:length(idxs)-1
+        print(io, idxs[i], ", ")
+    end
+    println(io, idxs[end], "] =")
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,13 @@ ghost2 = [
 @test_reference "references/braille_ghost.txt" @capture_out uprint(iseven, ghost2)
 @test_reference "references/block_ghost.txt" @capture_out uprint(iseven, ghost2, :block)
 
+# Test vector and n-dimensional arrays
+v = [0, 1, 0, 1, 1, 0, 0, 1]
+@test ustring(v) == "⠈⠈⠁⠈\n"
+
+A = reshape(v, 2, 2, 1, 1, 2)
+@test ustring(A) == "[:, :, 1, 1, 1] =\n⠒\n\n[:, :, 1, 1, 2] =\n⠑\n"
+
 # Remove deprecations before next breaking release:
 @test_reference "references/braille_ghost.txt" (@test_deprecated brailize(ghost))
 @test_reference "references/block_ghost.txt" (@test_deprecated blockize(ghost))


### PR DESCRIPTION
Previously, UnicodeGraphics only supported printing inputs of type `AbstractMatrix`.
This PR adds support for all `AbstractArray`, printing them in a similar manner to Julia Base.

```Julia
julia> A = rand(Bool, 4, 4, 1, 2)
4×4×1×2 Array{Bool, 4}:
[:, :, 1, 1] =
 0  1  0  0
 1  0  1  0
 0  1  1  1
 0  0  1  1

[:, :, 1, 2] =
 1  1  0  0
 1  1  0  0
 0  0  1  0
 0  0  1  0

julia> uprint(A, :block)
[:, :, 1, 1] =
▄▀▄ 
 ▀██

[:, :, 1, 2] =
██  
  █ 
```

Vectors are now also supported:
```Julia
julia> v = rand(Bool, 10)
10-element Vector{Bool}:
 0
 1
 1
 1
 0
 0
 0
 0
 0
 1

julia> uprint(v)
⠈⠉⠀⠀⠈
```

This combined with filtering functions turns UnicodeGraphics into a more powerful version of UnicodePlot's `spy`:
```Julia
julia> R = rand(4, 4, 2);

julia> I = rand(4, 4, 2);

julia> C = Complex.(R, I)
4×4×2 Array{ComplexF64, 3}:
[:, :, 1] =
 0.179834+0.67723im   0.844143+0.0501571im  0.245962+0.33609im    0.37915+0.473798im
 0.158714+0.518443im  0.547964+0.781685im   0.468971+0.490138im  0.498329+0.424635im
  0.50798+0.587343im  0.286937+0.885831im   0.943668+0.767205im  0.477409+0.230257im
 0.924134+0.515259im  0.187141+0.82097im    0.844205+0.750786im   0.86775+0.79251im

[:, :, 2] =
 0.460583+0.298343im  0.367273+0.831102im   0.976232+0.514234im  0.300766+0.409001im
 0.987664+0.696564im   0.98153+0.241049im  0.0768916+0.741151im   0.69316+0.313175im
 0.776776+0.720078im  0.300255+0.640669im   0.924636+0.43785im   0.866818+0.0831176im
 0.655797+0.305454im   0.65618+0.452634im   0.239168+0.830208im  0.777077+0.74287im

julia> uprint(x -> imag(x) > 0.5, C)
[:, :, 1] =
⣷⣄

[:, :, 2] =
⠮⣃
```